### PR TITLE
Support for Python.NET 3

### DIFF
--- a/fisher_py/net_wrapping/__init__.py
+++ b/fisher_py/net_wrapping/__init__.py
@@ -2,6 +2,12 @@ import clr
 import os
 from fisher_py.net_wrapping.net_wrapper_base import NetWrapperBase
 
+# codecs for implicit enum conversion
+import Python.Runtime
+
+Python.Runtime.PyObjectConversions.RegisterEncoder(Python.Runtime.Codecs.EnumPyIntCodec.Instance)
+Python.Runtime.PyObjectConversions.RegisterDecoder(Python.Runtime.Codecs.EnumPyIntCodec.Instance)
+
 
 # access .net standard dlls
 dll_path = os.path.join(os.path.split(__file__)[0], '..', 'dll')


### PR DESCRIPTION
Implicit int-enum conversion is no longer a default. Considering how this project is set up, I've added the necessary codec to do the conversion.

However, as of this PR's creation, there is a bug upstream in that codec waiting to be fixed and v3 is still in alpha.