### PR TITLE
Bug/scan event

### DIFF
--- a/fisher_py/data/scan_event.py
+++ b/fisher_py/data/scan_event.py
@@ -293,7 +293,7 @@ class ScanEvent(NetWrapperBase):
         Value:
         See ThermoFisher.CommonCore.Data.FilterEnums.MSOrderType for possible values
         """
-        return MsOrderType(self._get_wrapped_object_().MsOrder)
+        return MsOrderType(self._get_wrapped_object_().MSOrder)
 
     @property
     def dependent(self) -> TriState:

--- a/fisher_py/data/scan_event.py
+++ b/fisher_py/data/scan_event.py
@@ -596,7 +596,7 @@ class ScanEvent(NetWrapperBase):
         Returns:
         reaction details
         """
-        return Reaction(self._get_wrapped_object_().Reactions[index])
+        return Reaction(self._get_wrapped_object_().GetReaction(index))
 
     def get_source_fragmentation_info(self, index: int) -> float:
         """


### PR DESCRIPTION
Two fixes for for problems encountered in scan_event.py:

- `get_reaction(index)` replaced direct access to `Reactions[index]` with call to `GetReaction(index)`
- `ms_order()` fixed capitalization typo: was `MsOrder`, should be `MSOrder`